### PR TITLE
RIVA-2945: Bugfix/Update image Bundle usage to use .module

### DIFF
--- a/Sources/TracerUI/Extensions/UIImage+Tracer.swift
+++ b/Sources/TracerUI/Extensions/UIImage+Tracer.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIImage {
     static func inBundle(named name: String) -> UIImage {
-        guard let image = UIImage(named: name, in: Bundle(for: TraceUI.self), compatibleWith: nil) else {
+        guard let image = UIImage(named: name, in: .module, compatibleWith: nil) else {
             fatalError("Missing an image in the framework")
         }
         return image


### PR DESCRIPTION
Updates the `UIImage` creation to use the SPM `.module` bundle to avoid hitting the `fatalError`